### PR TITLE
fix(GUI) 完全卸载一个->完全包含在一个

### DIFF
--- a/docs/scenarios/gui.rst
+++ b/docs/scenarios/gui.rst
@@ -89,8 +89,8 @@ PySimpleGUI
 
   $ pip install pysimplegui
 
-PySimpleGUI 完全卸载一个 PySimpleGUI.py 文件中。
-如果 pip 安装不可用，可将 PySimpleGUI.py 文件粘贴到项目的文件夹中，就可以直接使用了。
+PySimpleGUI 完全包含在一个 PySimpleGUI.py 文件中。
+如果 pip 安装不可用，将 PySimpleGUI.py 粘贴到项目文件夹中以便引用，即可。
 
 Toga
 ----


### PR DESCRIPTION
原文:
> PySimpleGUI is contained in a single PySimpleGUI.py file

可能是机器翻译的? 并另外调整了此段其它文字, 更加通顺